### PR TITLE
Customize diagnostics and exercises via profile skill levels

### DIFF
--- a/app/pages/2_Resultat.py
+++ b/app/pages/2_Resultat.py
@@ -22,6 +22,19 @@ result: DiagnosticResult = st.session_state.result
 active_profile = profiles.get_profile(st.session_state.get("profile_id"))
 if active_profile:
     st.caption(f"Aktiv profil: {active_profile.label}")
+    pending_levels = {
+        topic: level
+        for topic, level in result.skill_profile.items()
+        if active_profile.skill_profile.get(topic) != level
+    }
+    if pending_levels:
+        try:
+            active_profile = profiles.update_profile(
+                active_profile.id,
+                skill_profile=pending_levels,
+            )
+        except ValueError:
+            active_profile = None
 
 st.header("Resultat")
 st.metric("Totalt antal frågor", result.total_questions)
@@ -35,5 +48,11 @@ for topic in result.topics:
     )
 
 if st.button("Beräkna rekommendationer", type="primary"):
-    st.session_state.recommendations = recommend_exercises(result)
+    grade = active_profile.last_grade if active_profile else None
+    skill_profile = active_profile.skill_profile if active_profile else None
+    st.session_state.recommendations = recommend_exercises(
+        result,
+        grade=grade,
+        skill_profile=skill_profile,
+    )
     st.success("Rekommendationer uppdaterade! Gå vidare till sidan '3_Ovningar'.")

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -103,8 +103,13 @@ with cols[1]:
 if st.button("Starta diagnostik"):
     st.session_state.grade = grade
     st.session_state.topic = topic
+    skill_profile = selected_profile.skill_profile if selected_profile else None
     try:
-        questions = diagnostics.generate_diagnostic(grade, [topic])
+        questions = diagnostics.generate_diagnostic(
+            grade,
+            [topic],
+            skill_profile=skill_profile,
+        )
     except ValueError as exc:
         st.error(str(exc))
     else:

--- a/services/diagnostics.py
+++ b/services/diagnostics.py
@@ -5,8 +5,8 @@ import json
 import logging
 import random
 from collections import Counter, defaultdict
-from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from typing import Any
 from uuid import uuid4
 
@@ -36,13 +36,39 @@ class DiagnosticConfig:
         }
 
 
-def generate_diagnostic(grade: int, topics: Sequence[str], config: DiagnosticConfig | None = None) -> list[Question]:
+def generate_diagnostic(
+    grade: int,
+    topics: Sequence[str],
+    config: DiagnosticConfig | None = None,
+    skill_profile: Mapping[str, int] | None = None,
+) -> list[Question]:
     if config is None:
         config = DiagnosticConfig()
-    dynamic_questions = _maybe_generate_dynamic(grade, topics, config)
+    adjusted_config = _adjust_config_for_skill(config, topics, skill_profile)
+    dynamic_questions = _maybe_generate_dynamic(grade, topics, adjusted_config)
     if dynamic_questions:
-        return dynamic_questions[: config.length]
-    return _generate_from_store(grade, topics, config)
+        return dynamic_questions[: adjusted_config.length]
+    return _generate_from_store(grade, topics, adjusted_config)
+
+
+def _adjust_config_for_skill(
+    config: DiagnosticConfig,
+    topics: Sequence[str],
+    skill_profile: Mapping[str, int] | None,
+) -> DiagnosticConfig:
+    if not skill_profile:
+        return config
+    levels = [skill_profile[topic] for topic in topics if topic in skill_profile]
+    if not levels:
+        return config
+    avg_level = sum(levels) / len(levels)
+    if avg_level < 2.5:
+        mix = {"easy": 0.6, "medium": 0.3, "hard": 0.1}
+    elif avg_level < 3.5:
+        mix = {"easy": 0.3, "medium": 0.5, "hard": 0.2}
+    else:
+        mix = {"easy": 0.2, "medium": 0.3, "hard": 0.5}
+    return replace(config, difficulty_mix=mix)
 
 
 def score_submission(submissions: Iterable[DiagnosticSubmission]) -> DiagnosticResult:

--- a/services/models.py
+++ b/services/models.py
@@ -117,6 +117,7 @@ class Profile(BaseModel):
     last_topic: str | None = None
     created_at: datetime
     updated_at: datetime
+    skill_profile: dict[str, int] = Field(default_factory=dict)
 
     @property
     def label(self) -> str:

--- a/services/profiles.py
+++ b/services/profiles.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -83,6 +83,7 @@ def update_profile(
     name: str | None = None,
     last_grade: int | None = None,
     last_topic: str | None = None,
+    skill_profile: Mapping[str, int] | None = None,
 ) -> Profile:
     profiles = load_profiles()
     updated: Profile | None = None
@@ -100,6 +101,10 @@ def update_profile(
             data["last_grade"] = int(last_grade)
         if last_topic is not None:
             data["last_topic"] = last_topic
+        if skill_profile is not None:
+            merged = dict(profile.skill_profile)
+            merged.update(skill_profile)
+            data["skill_profile"] = merged
         data["updated_at"] = datetime.now(UTC)
         updated = Profile.model_validate(data)
         new_profiles.append(updated)

--- a/services/recommendations.py
+++ b/services/recommendations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from . import content
 from .models import DiagnosticResult, Question
 
@@ -11,38 +13,68 @@ LEVEL_TO_DIFFICULTY = {
     5: "hard",
 }
 
+LEVEL_TO_DIFFICULTY_ORDER = {
+    1: ["easy", "medium", "hard"],
+    2: ["easy", "medium", "hard"],
+    3: ["medium", "easy", "hard"],
+    4: ["medium", "hard", "easy"],
+    5: ["hard", "medium", "easy"],
+}
 
-def _questions_for_topic(topic: str) -> list[Question]:
+
+def _questions_for_topic(topic: str, *, grade: int | None = None) -> list[Question]:
     store = content.get_store()
-    return [question for question in store.questions.values() if question.topic == topic]
+    return [
+        question
+        for question in store.questions.values()
+        if question.topic == topic and (grade is None or question.grade == grade)
+    ]
 
 
-def recommend_exercises(result: DiagnosticResult, per_topic: int = 3) -> list[Question]:
-    store = content.get_store()
+def recommend_exercises(
+    result: DiagnosticResult,
+    *,
+    per_topic: int = 3,
+    grade: int | None = None,
+    skill_profile: Mapping[str, int] | None = None,
+) -> list[Question]:
     recommendations: list[Question] = []
     used_ids: set[str] = set()
 
     for topic_score in sorted(result.topics, key=lambda t: t.level):
-        desired_difficulty = LEVEL_TO_DIFFICULTY.get(topic_score.level, "medium")
-        topic_questions = _questions_for_topic(topic_score.topic)
-        preferred = [q for q in topic_questions if q.difficulty == desired_difficulty]
-        pool = preferred if len(preferred) >= per_topic else topic_questions
-        for question in pool:
-            if question.id in used_ids:
-                continue
-            recommendations.append(question)
-            used_ids.add(question.id)
-            if sum(1 for q in recommendations if q.topic == topic_score.topic) >= per_topic:
-                break
+        target_level = (
+            skill_profile.get(topic_score.topic, topic_score.level)
+            if skill_profile
+            else topic_score.level
+        )
+        desired_difficulty = LEVEL_TO_DIFFICULTY.get(target_level, "medium")
+        difficulties = LEVEL_TO_DIFFICULTY_ORDER.get(
+            target_level, [desired_difficulty, "medium", "easy", "hard"]
+        )
+        topic_questions = _questions_for_topic(topic_score.topic, grade=grade)
+        if not topic_questions:
+            topic_questions = _questions_for_topic(topic_score.topic)
 
-    if not recommendations:
-        # fallback: select first N questions regardless of topic
-        for question in store.questions.values():
-            if question.id in used_ids:
-                continue
-            recommendations.append(question)
-            used_ids.add(question.id)
-            if len(recommendations) >= per_topic * max(1, len(result.topics)):
+        collected = 0
+        for difficulty in difficulties:
+            for question in topic_questions:
+                if question.id in used_ids or question.difficulty != difficulty:
+                    continue
+                recommendations.append(question)
+                used_ids.add(question.id)
+                collected += 1
+                if collected >= per_topic:
+                    break
+            if collected >= per_topic:
                 break
+        if collected < per_topic:
+            for question in topic_questions:
+                if question.id in used_ids:
+                    continue
+                recommendations.append(question)
+                used_ids.add(question.id)
+                collected += 1
+                if collected >= per_topic:
+                    break
 
     return recommendations

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -53,3 +53,18 @@ def test_generate_diagnostic_fallback_when_dynamic_empty(monkeypatch) -> None:
     config = diagnostics.DiagnosticConfig(length=4)
     questions = diagnostics.generate_diagnostic(7, ["Taluppfattning"], config)
     assert len(questions) == 4
+
+
+def test_generate_diagnostic_uses_skill_profile(monkeypatch) -> None:
+    monkeypatch.setattr(
+        diagnostics, "_maybe_generate_dynamic", lambda grade, topics, config: []
+    )
+    monkeypatch.setattr(diagnostics.random, "sample", lambda seq, k: list(seq)[:k])
+    config = diagnostics.DiagnosticConfig(length=3, prefer_dynamic=False)
+    questions = diagnostics.generate_diagnostic(
+        7,
+        ["Taluppfattning"],
+        config,
+        skill_profile={"Taluppfattning": 5},
+    )
+    assert any(question.difficulty == "hard" for question in questions)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -18,9 +18,15 @@ def test_profile_lifecycle(monkeypatch, tmp_path) -> None:
     updated = profiles.update_profile(created.id, last_topic="Algebra")
     assert updated.last_topic == "Algebra"
 
+    enhanced = profiles.update_profile(
+        created.id, skill_profile={"Taluppfattning": 3}
+    )
+    assert enhanced.skill_profile["Taluppfattning"] == 3
+
     fetched = profiles.get_profile(created.id)
     assert fetched is not None
     assert fetched.last_topic == "Algebra"
+    assert fetched.skill_profile["Taluppfattning"] == 3
 
     profiles.delete_profile(created.id)
     assert profiles.list_profiles() == []

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -13,6 +13,36 @@ def test_recommendations_return_questions() -> None:
         DiagnosticSubmission(question=store.questions["g7_proc_001"], submitted_answer="20"),
     ]
     result = score_submission(submissions)
-    recs = recommend_exercises(result, per_topic=2)
+    recs = recommend_exercises(
+        result,
+        per_topic=2,
+        grade=7,
+        skill_profile={"Taluppfattning": 4},
+    )
     assert len(recs) >= 2
     assert all(rec.topic in result.skill_profile for rec in recs)
+    assert all(rec.grade == 7 for rec in recs)
+
+
+def test_recommendations_use_skill_profile_levels() -> None:
+    store = get_store()
+    submissions = [
+        DiagnosticSubmission(
+            question=store.questions["g7_aritmetik_001"], submitted_answer="10"
+        )
+    ]
+    result = score_submission(submissions)
+    advanced = recommend_exercises(
+        result,
+        per_topic=2,
+        grade=7,
+        skill_profile={"Taluppfattning": 5},
+    )
+    beginner = recommend_exercises(
+        result,
+        per_topic=2,
+        grade=7,
+        skill_profile={"Taluppfattning": 1},
+    )
+    assert any(question.difficulty == "hard" for question in advanced)
+    assert any(question.difficulty == "easy" for question in beginner)


### PR DESCRIPTION
## Summary
- store per-topic skill levels on profiles and persist them after scoring diagnostics
- tailor diagnostic generation and recommended exercises based on stored skill data and the topics covered
- ensure recommendations stay within the tested grade/topic scope and expand automated tests around the new behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dea9933d78833188bec920bbfdc8c6