### PR TITLE
Ensure Streamlit app resolves services package imports

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Streamlit application package."""

--- a/app/_bootstrap.py
+++ b/app/_bootstrap.py
@@ -1,0 +1,14 @@
+"""Utilities for ensuring the project root is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_ROOT_STR = str(_ROOT)
+
+if _ROOT_STR not in sys.path:
+    sys.path.insert(0, _ROOT_STR)
+
+__all__ = ("_ROOT", "_ROOT_STR")

--- a/app/pages/1_Diagnostik.py
+++ b/app/pages/1_Diagnostik.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import streamlit as st
 
-ROOT = Path(__file__).resolve().parents[2]
-if (root_str := str(ROOT)) not in sys.path:
-    sys.path.insert(0, root_str)
-
+from app import _bootstrap  # noqa: F401
 from services import profiles
 from services.models import DiagnosticSubmission
 

--- a/app/pages/1_Diagnostik.py
+++ b/app/pages/1_Diagnostik.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import streamlit as st
+
+ROOT = Path(__file__).resolve().parents[2]
+if (root_str := str(ROOT)) not in sys.path:
+    sys.path.insert(0, root_str)
 
 from services import profiles
 from services.models import DiagnosticSubmission

--- a/app/pages/2_Resultat.py
+++ b/app/pages/2_Resultat.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import streamlit as st
+
+ROOT = Path(__file__).resolve().parents[2]
+if (root_str := str(ROOT)) not in sys.path:
+    sys.path.insert(0, root_str)
 
 from services import profiles
 from services.diagnostics import score_submission

--- a/app/pages/2_Resultat.py
+++ b/app/pages/2_Resultat.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import streamlit as st
 
-ROOT = Path(__file__).resolve().parents[2]
-if (root_str := str(ROOT)) not in sys.path:
-    sys.path.insert(0, root_str)
-
+from app import _bootstrap  # noqa: F401
 from services import profiles
 from services.diagnostics import score_submission
 from services.models import DiagnosticResult, DiagnosticSubmission

--- a/app/pages/3_Ovningar.py
+++ b/app/pages/3_Ovningar.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-from pathlib import Path
 
 import streamlit as st
 
-ROOT = Path(__file__).resolve().parents[2]
-if (root_str := str(ROOT)) not in sys.path:
-    sys.path.insert(0, root_str)
-
+from app import _bootstrap  # noqa: F401
 from llm.base import NullLLMProvider
 from llm.deepseek import get_llm_provider
 from services import profiles

--- a/app/pages/3_Ovningar.py
+++ b/app/pages/3_Ovningar.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+from pathlib import Path
 
 import streamlit as st
+
+ROOT = Path(__file__).resolve().parents[2]
+if (root_str := str(ROOT)) not in sys.path:
+    sys.path.insert(0, root_str)
 
 from llm.base import NullLLMProvider
 from llm.deepseek import get_llm_provider

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import streamlit as st
 from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parents[1]
+if (root_str := str(ROOT)) not in sys.path:
+    sys.path.insert(0, root_str)
 
 from services import content, diagnostics, profiles
 

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import streamlit as st
 from dotenv import load_dotenv
 
-ROOT = Path(__file__).resolve().parents[1]
-if (root_str := str(ROOT)) not in sys.path:
-    sys.path.insert(0, root_str)
-
+from app import _bootstrap  # noqa: F401
 from services import content, diagnostics, profiles
 
 load_dotenv()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+import importlib
+from contextlib import AbstractContextManager
+from typing import Any, Protocol, cast
+
 import pytest
-import respx
 from httpx import Response
 
 from llm.deepseek import DeepSeekProvider
 from services.content import get_store
 from services.models import LLMFeedbackRequest
+
+
+class _RespxModule(Protocol):
+    def mock(self, *, base_url: str) -> AbstractContextManager[Any]: ...
+
+
+respx = cast(_RespxModule, importlib.import_module("respx"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a sys.path bootstrap to the main Streamlit entrypoint so `services` is importable during startup
- apply the same bootstrap to each page module to keep imports consistent across Streamlit Cloud

## Testing
- `timeout 5 streamlit run app/streamlit_app.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68dec60e75dc8331ba862dc1665c76be