### PR TITLE
Handle missing app package import when starting Streamlit app

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 import streamlit as st
 from dotenv import load_dotenv
 
-from app import _bootstrap  # noqa: F401
+try:
+    from app import _bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - defensive path for local runs
+    import sys
+    from pathlib import Path
+
+    _ROOT = Path(__file__).resolve().parents[1]
+    _ROOT_STR = str(_ROOT)
+    if _ROOT_STR not in sys.path:
+        sys.path.insert(0, _ROOT_STR)
+
+    from app import _bootstrap  # noqa: F401
 from services import content, diagnostics, profiles
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- add a defensive bootstrap in `streamlit_app.py` to ensure the project root is added to `sys.path`
- retry importing the internal bootstrap helper after updating `sys.path` so Streamlit can start outside a package-aware context

## Testing
- `pytest` *(fails: missing optional dependency `respx` required by tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dece7463008331a96a703d5bce93f9