### PR TITLE
Add question bank controls and improve diagnostic feedback

### DIFF
--- a/app/pages/4_Frågebank.py
+++ b/app/pages/4_Frågebank.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+from llm.deepseek import get_chat_client
+from services import content
+from services.question_bank import (
+    GENERATED_DIR,
+    CurriculumQuestionBankBuilder,
+    QuestionBankRequest,
+)
+
+st.title("Frågebank (DeepSeek)")
+st.write(
+    "Skapa och återanvänd större frågebanker med hjälp av DeepSeek. "
+    "Frågorna sparas lokalt och kan återanvändas vid framtida körningar."
+)
+
+client_available = get_chat_client() is not None
+if not client_available:
+    st.warning(
+        "DeepSeek är inte konfigurerat ännu. Sätt `DEEPSEEK_API_KEY` för att kunna "
+        "generera nya frågor."
+    )
+
+grade = st.selectbox("Årskurs", [7, 8, 9], index=[7, 8, 9].index(st.session_state.get("grade", 7)))
+all_topics = content.list_topics(grade)
+selected_topics = st.multiselect("Ämnen", options=all_topics, default=all_topics[:1])
+
+col_config = st.columns(2)
+with col_config[0]:
+    total_questions = st.slider("Antal frågor totalt", min_value=10, max_value=120, step=10, value=60)
+    temperature = st.slider("Temperature", min_value=0.0, max_value=1.2, value=0.6, step=0.1)
+with col_config[1]:
+    max_tokens = st.slider("Max tokens per svar", min_value=900, max_value=3200, value=2200, step=100)
+    refresh = st.checkbox("Skapa om även om fil finns", value=False)
+
+builder = CurriculumQuestionBankBuilder()
+
+if st.button("Generera frågebank", disabled=not client_available):
+    request = QuestionBankRequest(
+        grade=grade,
+        topics=selected_topics,
+        total_questions=total_questions,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        refresh=refresh,
+    )
+    try:
+        output_path = builder.build(request)
+    except Exception as exc:  # noqa: BLE001
+        st.error(f"Kunde inte generera frågebank: {exc}")
+    else:
+        try:
+            display_path = output_path.relative_to(Path.cwd())
+        except ValueError:
+            display_path = output_path
+        st.success(
+            "Frågebanken genererades! Filen finns på: "
+            f"`{display_path}`"
+        )
+
+st.markdown("---")
+st.subheader("Tillgängliga frågebanker")
+existing_files = sorted(GENERATED_DIR.glob("*.json"))
+if not existing_files:
+    st.info("Inga genererade frågebanker hittades ännu.")
+else:
+    for file_path in existing_files:
+        try:
+            display_path = file_path.relative_to(Path.cwd())
+        except ValueError:
+            display_path = file_path
+        st.write(f"• `{display_path}`")

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -125,10 +125,10 @@ def _run_and_store_diagnostic(
     skill_profile: Mapping[str, int] | None,
     max_tokens: int | None = None,
 ) -> None:
-    config_kwargs: dict[str, object] = {}
     if max_tokens is not None:
-        config_kwargs["max_tokens"] = max_tokens
-    config = diagnostics.DiagnosticConfig(**config_kwargs)
+        config = diagnostics.DiagnosticConfig(max_tokens=max_tokens)
+    else:
+        config = diagnostics.DiagnosticConfig()
     outcome = diagnostics.generate_diagnostic(
         grade,
         [topic],

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import streamlit as st
 from dotenv import load_dotenv
 
@@ -35,6 +37,10 @@ if "recommendations" not in st.session_state:
     st.session_state.recommendations = []
 if "profile_id" not in st.session_state:
     st.session_state.profile_id = None
+if "last_diagnostic_request" not in st.session_state:
+    st.session_state.last_diagnostic_request = None
+if "dynamic_generation_feedback" not in st.session_state:
+    st.session_state.dynamic_generation_feedback = None
 
 st.title("Matte Diagnostik för årskurs 7–9")
 st.markdown(
@@ -112,33 +118,104 @@ with cols[1]:
             except ValueError:
                 st.session_state.profile_id = None
 
+def _run_and_store_diagnostic(
+    *,
+    grade: int,
+    topic: str,
+    skill_profile: Mapping[str, int] | None,
+    max_tokens: int | None = None,
+) -> None:
+    config_kwargs: dict[str, object] = {}
+    if max_tokens is not None:
+        config_kwargs["max_tokens"] = max_tokens
+    config = diagnostics.DiagnosticConfig(**config_kwargs)
+    outcome = diagnostics.generate_diagnostic(
+        grade,
+        [topic],
+        config,
+        skill_profile=skill_profile,
+    )
+    st.session_state.diagnostic_questions = outcome.questions
+    st.session_state.submissions = []
+    st.session_state.result = None
+    st.session_state.recommendations = []
+    st.session_state.dynamic_generation_feedback = None
+    if outcome.source == "store" and outcome.dynamic_error:
+        st.session_state.dynamic_generation_feedback = {
+            "error": outcome.dynamic_error,
+            "grade": grade,
+            "topic": topic,
+        }
+    if st.session_state.profile_id and topic != "Ingen data":
+        try:
+            profiles.update_profile(
+                st.session_state.profile_id,
+                last_grade=grade,
+                last_topic=topic,
+            )
+        except ValueError:
+            st.session_state.profile_id = None
+    success_message = (
+        "Nya frågor skapades med DeepSeek!"
+        if outcome.source == "dynamic"
+        else "Frågor hämtades från lokala biblioteket."
+    )
+    st.success(
+        f"Diagnostik startad! {success_message} Gå till sidan '1_Diagnostik' för att börja."
+    )
+
+
 if st.button("Starta diagnostik"):
     st.session_state.grade = grade
     st.session_state.topic = topic
     skill_profile = selected_profile.skill_profile if selected_profile else None
+    st.session_state.last_diagnostic_request = {
+        "grade": grade,
+        "topic": topic,
+        "skill_profile": skill_profile,
+    }
     try:
-        questions = diagnostics.generate_diagnostic(
-            grade,
-            [topic],
+        _run_and_store_diagnostic(
+            grade=grade,
+            topic=topic,
             skill_profile=skill_profile,
         )
     except ValueError as exc:
         st.error(str(exc))
-    else:
-        st.session_state.diagnostic_questions = questions
-        st.session_state.submissions = []
-        st.session_state.result = None
-        st.session_state.recommendations = []
-        if st.session_state.profile_id and topic != "Ingen data":
-            try:
-                profiles.update_profile(
-                    st.session_state.profile_id,
-                    last_grade=grade,
-                    last_topic=topic,
-                )
-            except ValueError:
-                st.session_state.profile_id = None
-        st.success("Diagnostik startad! Gå till sidan '1_Diagnostik' för att börja.")
+
+feedback = st.session_state.dynamic_generation_feedback
+if feedback:
+    st.warning(
+        "Det gick inte att skapa nya frågor med DeepSeek: "
+        f"{feedback['error']}\n"
+        "Du kan använda frågorna från biblioteket eller försöka igen."
+    )
+    retry_cols = st.columns(2)
+    with retry_cols[0]:
+        if st.button("Försök igen nu", key="retry_dynamic_now"):
+            request = st.session_state.last_diagnostic_request
+            if request:
+                try:
+                    _run_and_store_diagnostic(
+                        grade=request["grade"],
+                        topic=request["topic"],
+                        skill_profile=request["skill_profile"],
+                    )
+                except ValueError as exc:
+                    st.error(str(exc))
+    with retry_cols[1]:
+        if st.button("Försök igen (längre svarstid)", key="retry_dynamic_slow"):
+            request = st.session_state.last_diagnostic_request
+            if request:
+                try:
+                    _run_and_store_diagnostic(
+                        grade=request["grade"],
+                        topic=request["topic"],
+                        skill_profile=request["skill_profile"],
+                        max_tokens=2600,
+                    )
+                except ValueError as exc:
+                    st.error(str(exc))
 
 st.markdown("---")
 st.write("Använd sidomenyn för att navigera mellan diagnos, resultat och övningar.")

--- a/services/diagnostics.py
+++ b/services/diagnostics.py
@@ -6,6 +6,7 @@ import random
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
+from typing import Literal
 
 from llm.deepseek import get_chat_client
 
@@ -25,6 +26,8 @@ class DiagnosticConfig:
     )
     prefer_dynamic: bool = True
     curriculum_hint: str | None = None
+    temperature: float = 0.6
+    max_tokens: int = 1800
 
     def __post_init__(self) -> None:
         total = sum(self.difficulty_mix.values())
@@ -35,19 +38,40 @@ class DiagnosticConfig:
         }
 
 
+@dataclass(slots=True)
+class DiagnosticGenerationOutcome:
+    questions: list[Question]
+    source: Literal["dynamic", "store"]
+    dynamic_error: str | None = None
+
+
 def generate_diagnostic(
     grade: int,
     topics: Sequence[str],
     config: DiagnosticConfig | None = None,
     skill_profile: Mapping[str, int] | None = None,
-) -> list[Question]:
+) -> DiagnosticGenerationOutcome:
     if config is None:
         config = DiagnosticConfig()
     adjusted_config = _adjust_config_for_skill(config, topics, skill_profile)
-    dynamic_questions = _maybe_generate_dynamic(grade, topics, adjusted_config)
+    dynamic_error: str | None = None
+    dynamic_questions: list[Question] | None = None
+    try:
+        dynamic_questions = _maybe_generate_dynamic(grade, topics, adjusted_config)
+    except DynamicGenerationError as exc:
+        dynamic_error = str(exc)
     if dynamic_questions:
-        return dynamic_questions[: adjusted_config.length]
-    return _generate_from_store(grade, topics, adjusted_config)
+        return DiagnosticGenerationOutcome(
+            dynamic_questions[: adjusted_config.length],
+            source="dynamic",
+            dynamic_error=dynamic_error,
+        )
+    fallback_questions = _generate_from_store(grade, topics, adjusted_config)
+    return DiagnosticGenerationOutcome(
+        fallback_questions,
+        source="store",
+        dynamic_error=dynamic_error,
+    )
 
 
 def _adjust_config_for_skill(
@@ -143,6 +167,10 @@ def _generate_from_store(grade: int, topics: Sequence[str], config: DiagnosticCo
     return selected[: config.length]
 
 
+class DynamicGenerationError(RuntimeError):
+    pass
+
+
 def _maybe_generate_dynamic(
     grade: int,
     topics: Sequence[str],
@@ -152,7 +180,9 @@ def _maybe_generate_dynamic(
         return None
     client = get_chat_client()
     if client is None:
-        return None
+        raise DynamicGenerationError(
+            "DeepSeek är inte konfigurerat. Sätt DEEPSEEK_API_KEY för att skapa nya frågor."
+        )
     outline = config.curriculum_hint or _build_curriculum_outline(grade, topics)
     generator = DeepSeekQuestionGenerator(client)
     try:
@@ -163,14 +193,17 @@ def _maybe_generate_dynamic(
                 config.length,
                 config.difficulty_mix,
                 outline,
+                temperature=config.temperature,
+                max_tokens=config.max_tokens,
             )
         )
     except RuntimeError as exc:
-        logger.warning("Dynamic diagnostic generation avbruten: %s", exc)
-        return None
+        message = f"Dynamic diagnostic generation avbruten: {exc}"
+        logger.warning(message)
+        raise DynamicGenerationError(str(exc)) from exc
     except Exception as exc:  # noqa: BLE001
         logger.exception("Dynamic diagnostic generation failed: %s", exc)
-        return None
+        raise DynamicGenerationError("Ett oväntat fel uppstod vid generering.") from exc
 
 
 def _build_curriculum_outline(grade: int, topics: Sequence[str]) -> str:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,8 +6,11 @@ from services.models import DiagnosticSubmission, Question
 
 
 def test_generate_diagnostic_returns_requested_length() -> None:
-    questions = diagnostics.generate_diagnostic(7, ["Taluppfattning"], diagnostics.DiagnosticConfig(length=5))
-    assert len(questions) == 5
+    outcome = diagnostics.generate_diagnostic(
+        7, ["Taluppfattning"], diagnostics.DiagnosticConfig(length=5)
+    )
+    assert len(outcome.questions) == 5
+    assert outcome.source == "store"
 
 
 def test_score_submission_creates_topic_scores() -> None:
@@ -40,10 +43,11 @@ def test_generate_diagnostic_uses_dynamic(monkeypatch) -> None:
         lambda grade, topics, config: [dynamic_question],
     )
 
-    questions = diagnostics.generate_diagnostic(
+    outcome = diagnostics.generate_diagnostic(
         7, ["Taluppfattning"], diagnostics.DiagnosticConfig(length=3)
     )
-    assert questions == [dynamic_question]
+    assert outcome.source == "dynamic"
+    assert outcome.questions == [dynamic_question]
 
 
 def test_generate_diagnostic_fallback_when_dynamic_empty(monkeypatch) -> None:
@@ -51,8 +55,9 @@ def test_generate_diagnostic_fallback_when_dynamic_empty(monkeypatch) -> None:
         diagnostics, "_maybe_generate_dynamic", lambda grade, topics, config: []
     )
     config = diagnostics.DiagnosticConfig(length=4)
-    questions = diagnostics.generate_diagnostic(7, ["Taluppfattning"], config)
-    assert len(questions) == 4
+    outcome = diagnostics.generate_diagnostic(7, ["Taluppfattning"], config)
+    assert outcome.source == "store"
+    assert len(outcome.questions) == 4
 
 
 def test_generate_diagnostic_uses_skill_profile(monkeypatch) -> None:
@@ -61,10 +66,10 @@ def test_generate_diagnostic_uses_skill_profile(monkeypatch) -> None:
     )
     monkeypatch.setattr(diagnostics.random, "sample", lambda seq, k: list(seq)[:k])
     config = diagnostics.DiagnosticConfig(length=3, prefer_dynamic=False)
-    questions = diagnostics.generate_diagnostic(
+    outcome = diagnostics.generate_diagnostic(
         7,
         ["Taluppfattning"],
         config,
         skill_profile={"Taluppfattning": 5},
     )
-    assert any(question.difficulty == "hard" for question in questions)
+    assert any(question.difficulty == "hard" for question in outcome.questions)


### PR DESCRIPTION
## Summary
- surface DeepSeek generation feedback in the diagnostic start view with retry actions and extended max token option
- expand the diagnostics service to expose generation outcomes and configurable temperature/max token settings
- add a Streamlit question bank administration page and update diagnostics tests

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pypdf')*


------
https://chatgpt.com/codex/tasks/task_e_68dfa17acd54833188b55a7072846748