### PR TITLE
Improve DeepSeek error reporting

### DIFF
--- a/llm/deepseek.py
+++ b/llm/deepseek.py
@@ -63,9 +63,26 @@ class DeepSeekChatClient:
                     )
                     response.raise_for_status()
                     break
-                except (httpx.TimeoutException, httpx.HTTPStatusError, httpx.RequestError) as exc:
+                except (
+                    httpx.TimeoutException,
+                    httpx.HTTPStatusError,
+                    httpx.RequestError,
+                ) as exc:
                     if attempt >= self.max_retries:
-                        raise RuntimeError("DeepSeek API request failed") from exc
+                        details = ""
+                        if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+                            response_text = exc.response.text
+                            details = (
+                                " (status code "
+                                f"{exc.response.status_code}, response: {response_text})"
+                            )
+                        elif isinstance(exc, httpx.TimeoutException):
+                            details = " (request timed out)"
+                        elif isinstance(exc, httpx.RequestError) and exc.request is not None:
+                            details = f" (request error for {exc.request.url!r})"
+                        raise RuntimeError(
+                            f"DeepSeek API request failed{details}: {exc}"
+                        ) from exc
                     await asyncio.sleep(self.retry_backoff * (attempt + 1))
 
         try:

--- a/services/question_bank.py
+++ b/services/question_bank.py
@@ -134,7 +134,16 @@ class CurriculumQuestionBankBuilder:
                     )
                 )
             except RuntimeError as exc:
-                logger.warning("DeepSeek-förfrågan misslyckades (%s): %s", topic, exc)
+                cause = exc.__cause__ or exc.__context__
+                if cause is not None:
+                    logger.warning(
+                        "DeepSeek-förfrågan misslyckades (%s): %s (orsak: %s)",
+                        topic,
+                        exc,
+                        cause,
+                    )
+                else:
+                    logger.warning("DeepSeek-förfrågan misslyckades (%s): %s", topic, exc)
                 break
             if not batch:
                 logger.info("Inga frågor genererades för %s i försök %s", topic, attempts)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -43,7 +43,11 @@ async def test_deepseek_provider_error() -> None:
     provider = DeepSeekProvider(api_key="test-key", base_url="https://mocked")
     with respx.mock(base_url="https://mocked") as router:
         router.post("/").mock(return_value=Response(500, json={"error": "fail"}))
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as exc_info:
             await provider.feedback(
                 LLMFeedbackRequest(question=question, student_answer="11")
             )
+    message = str(exc_info.value)
+    assert "status code 500" in message
+    assert "fail" in message
+    assert exc_info.value.__cause__ is not None


### PR DESCRIPTION
## Summary
- include httpx response details when DeepSeek requests fail permanently
- log the underlying cause when question generation retries abort
- verify DeepSeek provider errors expose status codes and response bodies in tests

## Testing
- pytest tests/test_llm.py

------
https://chatgpt.com/codex/tasks/task_e_68dfa71913248331bd882eb7090356a9