### PR TITLE
Fix DeepSeek error handling and stabilize tests

### DIFF
--- a/llm/deepseek.py
+++ b/llm/deepseek.py
@@ -83,11 +83,11 @@ class DeepSeekChatClient:
                         error_text = _describe_exception(exc)
                         cause = exc.__cause__ or exc.__context__
                         if cause is not None:
-                            error_text = f"{error_text} (cause: {_describe_exception(cause)})"
+                            error_text = (
+                                f"{error_text} (cause: {_describe_exception(cause)})"
+                            )
                         raise RuntimeError(
                             f"DeepSeek API request failed{details}: {error_text}"
-                        raise RuntimeError(
-                            f"DeepSeek API request failed{details}: {exc}"
                         ) from exc
                     await asyncio.sleep(self.retry_backoff * (attempt + 1))
 
@@ -165,5 +165,5 @@ def get_chat_client() -> DeepSeekChatClient | None:
 def _describe_exception(exc: BaseException) -> str:
     message = str(exc).strip()
     if message:
-        return message
+        return f"{exc.__class__.__name__}: {message}"
     return exc.__class__.__name__

--- a/services/curriculum.py
+++ b/services/curriculum.py
@@ -5,7 +5,10 @@ from collections.abc import Sequence
 from functools import cache
 from pathlib import Path
 
-from pypdf import PdfReader
+try:
+    from pypdf import PdfReader
+except ModuleNotFoundError:  # pragma: no cover - exercised in environments without pypdf
+    PdfReader = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +39,13 @@ def get_curriculum_text(grade: int) -> str:
     if not path.exists():
         logger.warning("Kunde inte hitta läroplansfil för Åk %s (%s)", grade, path)
         return ""
+    if PdfReader is None:
+        logger.warning(
+            "Biblioteket pypdf saknas; återvänder tom läroplanstext för Åk %s.",
+            grade,
+        )
+        return ""
+
     reader = PdfReader(str(path))
     pages: list[str] = []
     for page in reader.pages:

--- a/services/question_bank.py
+++ b/services/question_bank.py
@@ -118,7 +118,7 @@ class CurriculumQuestionBankBuilder:
     ) -> list[Question]:
         questions: list[Question] = []
         attempts = 0
-        seen_stems: set[str] = {question.stem for question in questions}
+        seen_stems: set[str] = set()
         batch_size = max(5, min(15, target))
         self._ensure_health_check(generator)
         while len(questions) < target and attempts < 6:
@@ -143,7 +143,6 @@ class CurriculumQuestionBankBuilder:
                         topic,
                         exc,
                         _describe_exception(cause),
-                        cause,
                     )
                 else:
                     logger.warning("DeepSeek-förfrågan misslyckades (%s): %s", topic, exc)
@@ -198,7 +197,7 @@ class CurriculumQuestionBankBuilder:
 def _describe_exception(exc: BaseException) -> str:
     message = str(exc).strip()
     if message:
-        return message
+        return f"{exc.__class__.__name__}: {message}"
     return exc.__class__.__name__
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,24 +4,24 @@ import asyncio
 import sys
 import types
 from contextlib import AbstractContextManager
-import sys
-import types
 from typing import Any, Protocol, cast
 
 import httpx
 import pytest
 from httpx import Request, Response
 
-try:
+# The pdf module is optional in the test environment. Provide a lightweight stub
+# to satisfy the import used by the production code without bringing in heavy
+# dependencies.
+try:  # pragma: no cover - exercised implicitly during import
     import pypdf  # type: ignore  # noqa: F401
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover - executed in CI without pypdf
     fake_pypdf = types.ModuleType("pypdf")
     fake_pypdf.PdfReader = object  # type: ignore[attr-defined]
     sys.modules.setdefault("pypdf", fake_pypdf)
 
 from llm.deepseek import DeepSeekProvider
 from services.content import get_store
-from services.question_bank import CurriculumQuestionBankBuilder
 from services.models import LLMFeedbackRequest
 from services.question_bank import CurriculumQuestionBankBuilder
 
@@ -30,28 +30,33 @@ class _RespxModule(Protocol):
     def mock(self, *, base_url: str) -> AbstractContextManager[Any]: ...
 
 
-try:
+try:  # pragma: no cover - respx is optional in the runtime environment
     import respx as _respx_mod  # type: ignore
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover - executed in CI without respx
     _respx_mod = None
 
 respx = cast(_RespxModule | None, _respx_mod)
 
 
+@pytest.mark.skipif(respx is None, reason="respx is required for HTTP mocking")
 def test_deepseek_provider_success() -> None:
-    if respx is None:
-        pytest.skip("respx is required for HTTP mocking")
     store = get_store()
     question = store.questions["g7_aritmetik_001"]
     provider = DeepSeekProvider(api_key="test-key", base_url="https://mocked")
+
     async def _run() -> None:
         assert respx is not None
         with respx.mock(base_url="https://mocked") as router:
-            router.post("/").mock(return_value=Response(200, json={
-                "choices": [
-                    {"message": {"content": "Förklara på svenska"}}
-                ]
-            }))
+            router.post("/").mock(
+                return_value=Response(
+                    200,
+                    json={
+                        "choices": [
+                            {"message": {"content": "Förklara på svenska"}},
+                        ]
+                    },
+                )
+            )
             response = await provider.feedback(
                 LLMFeedbackRequest(question=question, student_answer="11")
             )
@@ -60,12 +65,12 @@ def test_deepseek_provider_success() -> None:
     asyncio.run(_run())
 
 
-def test_deepseek_provider_error() -> None:
-    if respx is None:
-        pytest.skip("respx is required for HTTP mocking")
+@pytest.mark.skipif(respx is None, reason="respx is required for HTTP mocking")
+def test_deepseek_provider_error_includes_status_and_body() -> None:
     store = get_store()
     question = store.questions["g7_aritmetik_001"]
     provider = DeepSeekProvider(api_key="test-key", base_url="https://mocked")
+
     async def _run() -> None:
         assert respx is not None
         with respx.mock(base_url="https://mocked") as router:
@@ -82,15 +87,13 @@ def test_deepseek_provider_error() -> None:
     asyncio.run(_run())
 
 
+@pytest.mark.skipif(respx is None, reason="respx is required for HTTP mocking")
 def test_deepseek_provider_timeout_includes_exception_name() -> None:
-    if respx is None:
-        pytest.skip("respx is required for HTTP mocking")
     store = get_store()
     question = store.questions["g7_aritmetik_001"]
     provider = DeepSeekProvider(api_key="test-key", base_url="https://mocked")
-    timeout_exc = httpx.TimeoutException(
-        "", request=Request("POST", "https://mocked/")
-    )
+    timeout_exc = httpx.TimeoutException("", request=Request("POST", "https://mocked/"))
+
     async def _run() -> None:
         assert respx is not None
         with respx.mock(base_url="https://mocked") as router:
@@ -110,14 +113,12 @@ def test_deepseek_provider_timeout_includes_exception_name() -> None:
 def test_question_bank_health_check_logs_cause(tmp_path, caplog) -> None:
     builder = CurriculumQuestionBankBuilder(output_dir=tmp_path)
 
-    class DummyCause(Exception):
     class DummyCauseError(Exception):
         pass
 
     class DummyClient:
         async def health_check(self) -> None:
-            raise RuntimeError("Yttre fel") from DummyCause()
-            raise RuntimeError("Yttre fel") from DummyCauseError()
+            raise RuntimeError("Yttre fel") from DummyCauseError("Inre fel")
 
     class DummyGenerator:
         def __init__(self) -> None:
@@ -125,17 +126,8 @@ def test_question_bank_health_check_logs_cause(tmp_path, caplog) -> None:
 
     with caplog.at_level("ERROR"):
         with pytest.raises(RuntimeError) as exc_info:
-            builder._ensure_health_check(DummyGenerator())
+            builder._ensure_health_check(cast(Any, DummyGenerator()))
+
     assert "DeepSeek-hälsokontrollen misslyckades" in str(exc_info.value)
-    assert any("DummyCause" in message for message in caplog.messages)
+    assert any("DummyCauseError" in message for message in caplog.messages)
     assert not builder._health_check_completed
-    with respx.mock(base_url="https://mocked") as router:
-        router.post("/").mock(return_value=Response(500, json={"error": "fail"}))
-        with pytest.raises(RuntimeError) as exc_info:
-            await provider.feedback(
-                LLMFeedbackRequest(question=question, student_answer="11")
-            )
-    message = str(exc_info.value)
-    assert "status code 500" in message
-    assert "fail" in message
-    assert exc_info.value.__cause__ is not None


### PR DESCRIPTION
## Summary
- fix DeepSeek client retry loop so failures raise informative errors without syntax issues
- allow curriculum loader to run without pypdf installed and clean up question bank logging
- rewrite llm tests to avoid merge artefacts and exercise DeepSeek error paths

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dfb46d47e083318648fc35e6032ddd