### PR TITLE
Fix DeepSeek diagnostics fallback

### DIFF
--- a/app/pages/4_Frågebank.py
+++ b/app/pages/4_Frågebank.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import streamlit as st
 
-from llm.deepseek import get_chat_client
+from llm.deepseek import get_chat_client, run_diagnostic_load_test
 from services import content
 from services.question_bank import (
     GENERATED_DIR,
@@ -19,7 +19,8 @@ st.write(
     "Frågorna sparas lokalt och kan återanvändas vid framtida körningar."
 )
 
-client_available = get_chat_client() is not None
+client = get_chat_client()
+client_available = client is not None
 if not client_available:
     st.warning(
         "DeepSeek är inte konfigurerat ännu. Sätt `DEEPSEEK_API_KEY` för att kunna "
@@ -27,7 +28,6 @@ if not client_available:
     )
 
 if st.button("Testa DeepSeek-anslutning", disabled=not client_available):
-    client = get_chat_client()
     if client is None:
         st.error("DeepSeek-klienten kunde inte initieras.")
     else:
@@ -38,6 +38,86 @@ if st.button("Testa DeepSeek-anslutning", disabled=not client_available):
                 st.error(f"Anslutningstestet misslyckades: {exc}")
             else:
                 st.success("Anslutningen fungerar!")
+
+with st.expander("Utökad anslutningsdiagnos", expanded=False):
+    st.write(
+        "Kör ett mer krävande test för att se hur DeepSeek svarar på större prompts "
+        "och längre svar."
+    )
+    diag_cols = st.columns(3)
+    with diag_cols[0]:
+        diag_steps = st.slider("Antal steg", min_value=1, max_value=5, value=3, key="diag_steps")
+        diag_initial = st.slider(
+            "Uppgifter i första steget",
+            min_value=1,
+            max_value=8,
+            value=2,
+            key="diag_initial",
+        )
+    with diag_cols[1]:
+        diag_increment = st.slider(
+            "Ökning av uppgifter per steg",
+            min_value=0,
+            max_value=5,
+            value=1,
+            key="diag_increment",
+        )
+        diag_max_tokens = st.slider(
+            "Max tokens i svaret",
+            min_value=128,
+            max_value=3200,
+            value=600,
+            step=64,
+            key="diag_max_tokens",
+        )
+    with diag_cols[2]:
+        diag_temperature = st.slider(
+            "Temperature för testet",
+            min_value=0.0,
+            max_value=1.2,
+            value=0.2,
+            step=0.1,
+            key="diag_temperature",
+        )
+    prompt_repeats = [diag_initial + i * diag_increment for i in range(diag_steps)]
+    st.caption(
+        "Stegvisa upprepningar i testet: "
+        + ", ".join(str(value) for value in prompt_repeats)
+    )
+    if st.button("Kör utökad anslutningsdiagnos", disabled=not client_available, key="run_diag"):
+        if client is None:
+            st.error("DeepSeek-klienten kunde inte initieras.")
+        else:
+            with st.spinner("Kör diagnostik..."):
+                try:
+                    results = asyncio.run(
+                        run_diagnostic_load_test(
+                            client,
+                            prompt_repeats,
+                            max_tokens=diag_max_tokens,
+                            temperature=diag_temperature,
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    st.error(f"Diagnostiken misslyckades: {exc}")
+                else:
+                    if not results:
+                        st.warning("Inga diagnostiksteg kördes.")
+                    for index, result in enumerate(results, start=1):
+                        label = (
+                            f"Steg {index}: {result.prompt_repeats} uppgifter, "
+                            f"max_tokens={result.max_tokens}"
+                        )
+                        if result.success:
+                            st.success(f"{label} – {result.duration:.2f} s")
+                            if result.response_preview:
+                                st.caption("Förhandsvisning av modellens svar")
+                                st.code(result.response_preview, language="markdown")
+                        else:
+                            st.error(
+                                f"{label} misslyckades efter {result.duration:.2f} s: {result.error}"
+                            )
+                            break
 
 grade = st.selectbox("Årskurs", [7, 8, 9], index=[7, 8, 9].index(st.session_state.get("grade", 7)))
 all_topics = content.list_topics(grade)

--- a/llm/deepseek.py
+++ b/llm/deepseek.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
+
+from time import perf_counter
 
 import httpx
 
@@ -19,12 +22,85 @@ Förklara steg för steg på svenska (max 120 ord) och uppmuntra eleven.
 """
 
 
+@dataclass(slots=True)
+class DeepSeekDiagnosticRun:
+    """Result information from a diagnostic DeepSeek invocation."""
+
+    prompt_repeats: int
+    max_tokens: int
+    duration: float
+    success: bool
+    error: str | None = None
+    response_preview: str | None = None
+
+
 def _render_prompt(request: LLMFeedbackRequest) -> str:
     return PROMPT_TEMPLATE.format(
         question_stem=request.question.stem,
         student_answer=request.student_answer,
         correct_answer=request.question.answer,
     )
+
+
+CompleteFn = Callable[
+    [Iterable[dict[str, str]]], Awaitable[str]
+]
+
+
+async def _run_diagnostic_load_test(
+    complete: CompleteFn,
+    prompt_repeats: Iterable[int],
+    *,
+    max_tokens: int = 512,
+    temperature: float = 0.0,
+) -> list[DeepSeekDiagnosticRun]:
+    """Run progressively heavier prompts with the provided completion callable."""
+
+    base_instruction = (
+        "Du är en hjälpsam mattelärare. Förklara resonemangen för varje uppgift nedan.\n\n"
+    )
+    sample_problem = (
+        "Problem: Beräkna 12 * 18 och redovisa alla steg.\n"
+        "Problem: Lös ekvationen 3x + 5 = 23 och motivera lösningen.\n"
+    )
+    results: list[DeepSeekDiagnosticRun] = []
+    for repeats in prompt_repeats:
+        prompt_body = sample_problem * max(repeats, 1)
+        messages = [
+            {"role": "system", "content": "Du är en hjälpsam mattelärare."},
+            {"role": "user", "content": base_instruction + prompt_body},
+        ]
+        start = perf_counter()
+        try:
+            response = await complete(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        except Exception as exc:  # noqa: BLE001 - propagate diagnostic info
+            duration = perf_counter() - start
+            results.append(
+                DeepSeekDiagnosticRun(
+                    prompt_repeats=repeats,
+                    max_tokens=max_tokens,
+                    duration=duration,
+                    success=False,
+                    error=str(exc),
+                )
+            )
+            break
+        duration = perf_counter() - start
+        preview = response.strip()
+        results.append(
+            DeepSeekDiagnosticRun(
+                prompt_repeats=repeats,
+                max_tokens=max_tokens,
+                duration=duration,
+                success=True,
+                response_preview=preview[:200] if preview else None,
+            )
+        )
+    return results
 
 
 class DeepSeekChatClient:
@@ -120,6 +196,21 @@ class DeepSeekChatClient:
         if not response.strip():
             raise RuntimeError("DeepSeek API health check returned an empty response.")
 
+    async def diagnostic_runs(
+        self,
+        prompt_repeats: Iterable[int],
+        *,
+        max_tokens: int = 512,
+        temperature: float = 0.0,
+    ) -> list[DeepSeekDiagnosticRun]:
+        """Run progressively heavier prompts to gauge response characteristics."""
+        return await _run_diagnostic_load_test(
+            self.complete,
+            prompt_repeats,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
 
 class DeepSeekProvider(LLMProvider):
     def __init__(
@@ -162,6 +253,43 @@ def get_chat_client() -> DeepSeekChatClient | None:
         return None
     base_url = os.getenv("DEEPSEEK_API_BASE_URL", "").strip() or None
     return DeepSeekChatClient(api_key, base_url=base_url)
+
+
+async def run_diagnostic_load_test(
+    client: Any,
+    prompt_repeats: Iterable[int],
+    *,
+    max_tokens: int = 512,
+    temperature: float = 0.0,
+) -> list[DeepSeekDiagnosticRun]:
+    """Run the diagnostic sequence against any DeepSeek-like client.
+
+    Falls back to the client's ``complete`` coroutine when ``diagnostic_runs`` is
+    not available (e.g. on legacy instances).
+    """
+
+    if hasattr(client, "diagnostic_runs"):
+        diagnostic = getattr(client, "diagnostic_runs")
+        if callable(diagnostic):
+            return await diagnostic(  # type: ignore[misc]
+                prompt_repeats,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+
+    if not hasattr(client, "complete"):
+        raise AttributeError("DeepSeek-klienten saknar stöd för anslutningsdiagnos.")
+
+    complete = getattr(client, "complete")
+    if not callable(complete):  # pragma: no cover - defensive guard
+        raise TypeError("DeepSeek-klientens 'complete'-attribut är inte anropbart.")
+
+    return await _run_diagnostic_load_test(
+        complete,  # type: ignore[arg-type]
+        prompt_repeats,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
 
 
 def _describe_exception(exc: BaseException) -> str:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -5,7 +5,7 @@ import importlib
 import sys
 import types
 from contextlib import AbstractContextManager
-from typing import Any, Protocol, cast
+from typing import Any, Iterable, Protocol, cast
 
 import httpx
 import pytest
@@ -21,7 +21,8 @@ except ModuleNotFoundError:  # pragma: no cover - executed in CI without pypdf
     setattr(fake_pypdf, "PdfReader", object)
     sys.modules.setdefault("pypdf", fake_pypdf)
 
-from llm.deepseek import DeepSeekProvider
+from llm import deepseek
+from llm.deepseek import DeepSeekChatClient, DeepSeekDiagnosticRun, DeepSeekProvider
 from services.content import get_store
 from services.models import LLMFeedbackRequest
 from services.question_bank import CurriculumQuestionBankBuilder
@@ -133,3 +134,69 @@ def test_question_bank_health_check_logs_cause(tmp_path, caplog) -> None:
     assert "DeepSeek-hälsokontrollen misslyckades" in str(exc_info.value)
     assert any("DummyCauseError" in message for message in caplog.messages)
     assert not builder._health_check_completed
+
+
+def test_deepseek_diagnostic_runs_stop_after_failure() -> None:
+    class DummyDiagnosticClient(DeepSeekChatClient):
+        def __init__(self) -> None:
+            super().__init__(api_key="test-key", base_url="https://mocked")
+            self._outcomes: list[str | Exception] = [
+                "Första svaret",
+                RuntimeError("misslyckades"),
+                "Ej använd",  # säkerställ att vi skulle ha fler värden vid behov
+            ]
+
+        async def complete(
+            self,
+            messages: Iterable[dict[str, str]],
+            *,
+            max_tokens: int = 350,
+            temperature: float = 0.7,
+        ) -> str:
+            assert messages, "diagnostik skickar alltid meddelanden"
+            outcome = self._outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    async def _run() -> None:
+        client = DummyDiagnosticClient()
+        results = await client.diagnostic_runs([1, 2, 3], max_tokens=128)
+        assert [result.prompt_repeats for result in results] == [1, 2]
+        assert all(isinstance(result, DeepSeekDiagnosticRun) for result in results)
+        assert results[0].success
+        assert not results[1].success
+        assert "misslyckades" in (results[1].error or "")
+
+    asyncio.run(_run())
+
+
+def test_run_diagnostic_load_test_supports_legacy_clients() -> None:
+    class LegacyClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, float]] = []
+
+        async def complete(
+            self,
+            messages: Iterable[dict[str, str]],
+            *,
+            max_tokens: int = 350,
+            temperature: float = 0.7,
+        ) -> str:
+            self.calls.append((max_tokens, temperature))
+            assert messages, "diagnostiken ska alltid ha meddelanden"
+            return "Svar från legacy-klient"
+
+    async def _run() -> None:
+        client = LegacyClient()
+        results = await deepseek.run_diagnostic_load_test(
+            client,
+            [1, 2],
+            max_tokens=256,
+            temperature=0.3,
+        )
+        assert len(results) == 2
+        assert all(result.success for result in results)
+        assert client.calls == [(256, 0.3), (256, 0.3)]
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- refactor DeepSeek diagnostic runs into a shared helper that can work with legacy clients
- expose a module-level `run_diagnostic_load_test` fallback and use it from the Streamlit frågebank page
- extend the unit test suite with coverage for the legacy fallback path

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dfe50b6c80833197a041694e6310d5