### PR TITLE
Fix DeepSeek diagnostic runs helper usage

### DIFF
--- a/llm/deepseek.py
+++ b/llm/deepseek.py
@@ -17,7 +17,6 @@ from .base import LLMProvider, NullLLMProvider
 from .deepseek_diagnostics import (
     DeepSeekDiagnosticRun,
     run_diagnostic_load_test,
-    run_diagnostic_sequence,
 )
 
 PROMPT_TEMPLATE = """Du är en hjälpsam mattelärare. Eleven har svarat på en fråga.
@@ -210,59 +209,12 @@ class DeepSeekChatClient:
         temperature: float = 0.0,
     ) -> list[DeepSeekDiagnosticRun]:
         """Run progressively heavier prompts to gauge response characteristics."""
-        return await run_diagnostic_sequence(
         return await _run_diagnostic_load_test(
             self.complete,
             prompt_repeats,
             max_tokens=max_tokens,
             temperature=temperature,
         )
-
-        base_instruction = (
-            "Du är en hjälpsam mattelärare. Förklara resonemangen för varje uppgift nedan.\n\n"
-        )
-        sample_problem = (
-            "Problem: Beräkna 12 * 18 och redovisa alla steg.\n"
-            "Problem: Lös ekvationen 3x + 5 = 23 och motivera lösningen.\n"
-        )
-        results: list[DeepSeekDiagnosticRun] = []
-        for repeats in prompt_repeats:
-            prompt_body = sample_problem * max(repeats, 1)
-            messages = [
-                {"role": "system", "content": "Du är en hjälpsam mattelärare."},
-                {"role": "user", "content": base_instruction + prompt_body},
-            ]
-            start = perf_counter()
-            try:
-                response = await self.complete(
-                    messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                )
-            except Exception as exc:  # noqa: BLE001 - propagate diagnostic info
-                duration = perf_counter() - start
-                results.append(
-                    DeepSeekDiagnosticRun(
-                        prompt_repeats=repeats,
-                        max_tokens=max_tokens,
-                        duration=duration,
-                        success=False,
-                        error=str(exc),
-                    )
-                )
-                break
-            duration = perf_counter() - start
-            preview = response.strip()
-            results.append(
-                DeepSeekDiagnosticRun(
-                    prompt_repeats=repeats,
-                    max_tokens=max_tokens,
-                    duration=duration,
-                    success=True,
-                    response_preview=preview[:200] if preview else None,
-                )
-            )
-        return results
 
 
 class DeepSeekProvider(LLMProvider):


### PR DESCRIPTION
## Summary
- remove the unused diagnostic sequence helper from DeepSeek chat client
- ensure the diagnostic run method uses the shared load test helper without duplicate code

## Testing
- python -m compileall llm/deepseek.py

------
https://chatgpt.com/codex/tasks/task_e_68e3be4c479483318664a0bee0815cb4