### PR TITLE
Allow overriding DeepSeek chat timeout per request

### DIFF
--- a/llm/deepseek.py
+++ b/llm/deepseek.py
@@ -55,8 +55,9 @@ class DeepSeekChatClient:
         *,
         max_tokens: int = 350,
         temperature: float = 0.7,
+        timeout: float | None = None,
     ) -> str:
-        timeout = httpx.Timeout(self.timeout)
+        timeout_config = httpx.Timeout(self.timeout if timeout is None else timeout)
         payload = {
             "model": "deepseek-chat",
             "messages": list(messages),
@@ -64,7 +65,7 @@ class DeepSeekChatClient:
             "temperature": temperature,
         }
         for attempt in range(self.max_retries + 1):
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(timeout=timeout_config) as client:
                 try:
                     response = await client.post(
                         self.base_url,

--- a/services/deepseek_generation.py
+++ b/services/deepseek_generation.py
@@ -68,7 +68,7 @@ class DeepSeekQuestionGenerator:
             ],
             max_tokens=max_tokens,
             temperature=temperature,
-            timeout = 45.0
+            timeout=45.0,
         )
         if self._debug_info is not None:
             self._debug_info.raw_response = response


### PR DESCRIPTION
## Summary
- allow DeepSeekChatClient.complete to accept an optional timeout override while preserving the default client timeout
- fix the question generator to use the new timeout override when creating question banks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3d2dcc22083318222d5d9b45a6969